### PR TITLE
Client mode

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -35,6 +35,7 @@ export default defineNuxtModule<ModuleOptions>({
     addComponent({
       name: "NuxtPlotly",
       filePath: resolver.resolve("./runtime/components/nuxt-plotly"),
+      mode: "client",
     });
 
     // Add runtime plugin


### PR DESCRIPTION
Since the component is client-only, it may be worth setting the mode to 'client' when adding the component in module.

documentation of `addComponent`: https://nuxt.com/docs/api/kit/components#addcomponent